### PR TITLE
Port to statismo 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prerequisites
 ------------
 
 You need to download and compile elastix and statismo. Both necessitate an installation of ITK.
-We tested statismo-elastix with elastix 4.6 and statismo 0.9.
+We tested statismo-elastix with elastix 4.6 and statismo 0.8.1, the current master. 
 
 You need a statistical deformation model in statismo's hdf5 file format. While it is possible to 
 build this model using registration results generated with elastix, this statismo-elastix software

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prerequisites
 ------------
 
 You need to download and compile elastix and statismo. Both necessitate an installation of ITK.
-We tested statismo-elastix with elastix 4.6 and statismo 0.8.1, the current master. 
+We tested statismo-elastix with elastix 4.7, ITK 4.5  and statismo 0.11.
 
 You need a statistical deformation model in statismo's hdf5 file format. While it is possible to 
 build this model using registration results generated with elastix, this statismo-elastix software

--- a/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
+++ b/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
@@ -1,7 +1,7 @@
 FIND_PACKAGE(STATISMO REQUIRED)
-include_directories(${STATISMO_INCLUDE_DIRS})
-link_directories(${STATISMO_LIBRARY_DIR})
-
+#Force elastix to link also statismo libraries 
+set(elxLinkLibs  ${statismo_LIBRARIES}  ${elxLinkLibs}  ) #${Boost_LIBRARIES}
+include_directories(${statismo_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} ) 
 ADD_ELXCOMPONENT( SimpleStatisticalDeformationModelTransformElastix
  itkAdvancedStatisticalDeformationModelTransform.h
  itkAdvancedStatisticalModelTransformBase.h

--- a/SimpleStatisticalDeformationModelTransform/elxStatisticalDeformationModelTransform.h
+++ b/SimpleStatisticalDeformationModelTransform/elxStatisticalDeformationModelTransform.h
@@ -20,7 +20,8 @@
 
 
 #include "itkStatisticalModel.h"
-#include "Representers/ITK/itkVectorImageRepresenter.h"
+#include "itkStandardImageRepresenter.h"
+
 #include "elxIncludes.h"
 #include "itkImage.h"
 #include "itkVector.h"
@@ -123,8 +124,10 @@ namespace elastix
     typedef typename Superclass2::CombinationTransformType  CombinationTransformType;
 
     /** Statismo typedefs */
-    typedef itk::VectorImageRepresenter<CoordRepType, elx::TransformBase<TElastix>::FixedImageDimension, elx::TransformBase<TElastix>::FixedImageDimension> RepresenterType;
-    typedef itk::StatisticalModel<RepresenterType> StatisticalModelType;
+	typedef itk::Vector<CoordRepType, elx::TransformBase<TElastix>::FixedImageDimension> VectorPixelType;
+    typedef itk::Image<VectorPixelType, elx::TransformBase<TElastix>::FixedImageDimension> ImageType;
+    typedef itk::StandardImageRepresenter<VectorPixelType, elx::TransformBase<TElastix>::FixedImageDimension> RepresenterType;
+	typedef itk::StatisticalModel<ImageType> StatisticalModelType;
 
     /** The ITK-class that provides most of the functionality, and
      * that is set as the "CurrentTransform" in the CombinationTransform */

--- a/SimpleStatisticalDeformationModelTransform/elxStatisticalDeformationModelTransform.hxx
+++ b/SimpleStatisticalDeformationModelTransform/elxStatisticalDeformationModelTransform.hxx
@@ -86,8 +86,8 @@ namespace elastix
     this->GetConfiguration()->ReadParameter( m_StatisticalModelName,
       "StatisticalModelName", 0);
     typename StatisticalModelType::Pointer statisticalModel = StatisticalModelType::New();
-
-    statisticalModel->Load(m_StatisticalModelName.c_str());
+	typename RepresenterType::Pointer representer = RepresenterType::New();
+	statisticalModel->Load(representer,m_StatisticalModelName.c_str());
 
     unsigned usedNumberOfStatisticalModelCoefficients = 0;
     this->GetConfiguration()->ReadParameter( usedNumberOfStatisticalModelCoefficients,  "UsedNumberOfStatisticalModelCoefficients", 0, false);
@@ -96,7 +96,7 @@ namespace elastix
     	this->m_StatisticalDeformationModelTransform->SetUsedNumberOfCoefficients(usedNumberOfStatisticalModelCoefficients);
     }
 
-    bool automaticTransformInitialization = false;
+    bool automaticTransformInitialization = false;		 
 
 		this->m_StatisticalModel = statisticalModel;
 

--- a/SimpleStatisticalDeformationModelTransform/itkAdvancedStatisticalDeformationModelTransform.h
+++ b/SimpleStatisticalDeformationModelTransform/itkAdvancedStatisticalDeformationModelTransform.h
@@ -38,7 +38,7 @@
 
 #include <iostream>
 #include "itkAdvancedStatisticalModelTransformBase.h"
-#include "itkVectorImageRepresenter.h"
+#include "itkStandardImageRepresenter.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkStatisticalModel.h"
 #include "itkImage.h"

--- a/SimpleStatisticalDeformationModelTransform/itkAdvancedStatisticalModelTransformBase.h
+++ b/SimpleStatisticalDeformationModelTransform/itkAdvancedStatisticalModelTransformBase.h
@@ -60,6 +60,8 @@
 #include "itkAdvancedTransform.h"
 #include "itkExceptionObject.h"
 #include "itkMacro.h"
+#include "itkImage.h"
+#include "itkVector.h"
 
 namespace itk
 {
@@ -80,7 +82,7 @@ namespace itk
 
 template <
 	class TRepresenter,									// Statismo Representer
-  class TScalarType=double,         // Data type for scalars
+  class TScalarType=float,         // Data type for scalars
   unsigned int TDimension=3  // Number of dimensions in the input space
   >
 class AdvancedStatisticalModelTransformBase
@@ -147,7 +149,10 @@ public:
   typedef typename Superclass::InternalMatrixType   InternalMatrixType;
 
 	typedef TRepresenter RepresenterType;
-	typedef itk::StatisticalModel<RepresenterType> StatisticalModelType;
+	typedef itk::Vector<TScalarType , TDimension> VectorPixelType;
+	typedef itk::Image<VectorPixelType, TDimension> VectorImageType;
+
+	typedef itk::StatisticalModel<VectorImageType>  StatisticalModelType;
 
   /** Set the transformation to an Identity
    * This sets the matrix to identity and the Offset to null.
@@ -307,7 +312,7 @@ private:
 
 }  // namespace itk
 
-#if ITK_TEMPLATE_TXX
+#ifndef ITK_MANUAL_INSTANTIATION 
 # include "itkAdvancedStatisticalModelTransformBase.txx"
 #endif
 


### PR DESCRIPTION
Hi,
I modified the component to run with the new statismo api, but statismo needs vector images of type double https://github.com/livia-b/statismo/commit/e9c6302024ade737364c250ab80dc8644792a37d .
I am not sure about the directive ITK_MANUAL_INSTANTIATION , but I followed the example in http://www.vtk.org/Wiki/ITK/Coding_Style_Guide#Class_Layout and I was able to run this code succesfully with the last superbuild of statismo
