### PR TITLE
lower case and correct TARGET_LINK_LIBRARIES in CMakeLists.txt

### DIFF
--- a/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
+++ b/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
@@ -1,6 +1,6 @@
-FIND_PACKAGE(STATISMO REQUIRED)
+FIND_PACKAGE(statismo REQUIRED)
 #Force elastix to link also statismo libraries 
-set(elxLinkLibs  ${statismo_LIBRARIES}  ${elxLinkLibs}  ) #${Boost_LIBRARIES}
+set(elxLinkLibs  ${statismo_LIBRARIES}  ${elxLinkLibs} ${Boost_LIBRARIES})
 include_directories(${statismo_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} ) 
 ADD_ELXCOMPONENT( SimpleStatisticalDeformationModelTransformElastix
  itkAdvancedStatisticalDeformationModelTransform.h

--- a/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
+++ b/SimpleStatisticalDeformationModelTransform/CMakeLists.txt
@@ -1,6 +1,4 @@
 FIND_PACKAGE(statismo REQUIRED)
-#Force elastix to link also statismo libraries 
-set(elxLinkLibs  ${statismo_LIBRARIES}  ${elxLinkLibs} ${Boost_LIBRARIES})
 include_directories(${statismo_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} ) 
 ADD_ELXCOMPONENT( SimpleStatisticalDeformationModelTransformElastix
  itkAdvancedStatisticalDeformationModelTransform.h
@@ -9,4 +7,4 @@ ADD_ELXCOMPONENT( SimpleStatisticalDeformationModelTransformElastix
  elxStatisticalDeformationModelTransform.h
  elxStatisticalDeformationModelTransform.hxx
  elxStatisticalDeformationModelTransform.cxx )
-
+TARGET_LINK_LIBRARIES( SimpleStatisticalDeformationModelTransformElastix statismo_core)


### PR DESCRIPTION
A bit delayed but I've merged the suggestions received for the CMakeLists.txt 
